### PR TITLE
Update installation method and support .nuclei-ignore file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ jobs:
       - uses: projectdiscovery/nuclei-action@main
         with:
           urls: "urls.txt"
-          output: "output.txt"
+          output: "nuclei.log"
 
       - uses: actions/upload-artifact@v2
         with:
-          name: output.txt
-          path: output.txt
+          name: nuclei.log
+          path: nuclei.log
 ```
 
 Inputs

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ on:
 
 jobs:
   worker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:      
       - uses: actions/checkout@v2      
 
@@ -28,8 +28,8 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: nuclei.log
-          path: nuclei.log
+          name: output.txt
+          path: output.txt
 ```
 
 Inputs

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: output.txt
-          path: output.txt
+          name: nuclei.log
+          path: nuclei.log
 ```
 
 Inputs

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
           -l ${{ inputs.urls }} \
           -t ${{ inputs.templates }} \
           -o ${{ inputs.output }} \
-          -H "User-Agent: ${{ inputs.user-agent }}"
+          -H "User-Agent: ${{ inputs.user-agent }}" \
           -json \
           -include-rr \
           \

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "File to save output result"
     required: false
     default: "output.txt"
+  nuclei-ignore:
+    description: "define templates that will be blocked from execution"
+    required: false
+    default: ".nuclei-ignore"
   user-agent:
     description: "Set a User-Agent header"
     required: false
@@ -23,20 +27,24 @@ runs:
   using: "composite"
   steps:
     - run: |
-        git clone https://github.com/projectdiscovery/nuclei.git
-        cd nuclei/v2/cmd/nuclei/
-        go build
-        echo "${{ github.workspace }}/nuclei/v2/cmd/nuclei" >> $GITHUB_PATH
+        GO111MODULE=on go get -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei
+        echo "/home/runner/go/bin/" >> $GITHUB_PATH
       shell: bash
 
     - run: |
         nuclei \
+          -update-templates \
+          -update-directory ./ \
+          \
+
+        test -e ${{ inputs.nuclei-ignore }} && cp ${{ inputs.nuclei-ignore }} nuclei-templates/.nuclei-ignore
+
+        nuclei \
           -l ${{ inputs.urls }} \
           -t ${{ inputs.templates }} \
           -o ${{ inputs.output }} \
+          -H "User-Agent: ${{ inputs.user-agent }}"
           -json \
           -include-rr \
-          -update-templates \
-          -update-directory ./ \
-          -H "User-Agent: ${{ inputs.user-agent }}"
+          \
       shell: bash


### PR DESCRIPTION
# Summary
- Update installation method to `go get` instead of `go build`
- Support .nuclei-ignore input to replace the original .nuclei-ignore downloaded with the latest nuclei-templates
- Minor changes in the README.md