### PR TITLE
group/collapse `go get` output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,8 +68,10 @@ runs:
   using: "composite"
   steps:
     - run: |
+        echo "::group::Install Nuclei with go get"
         [ ! -x /home/runner/go/bin/nuclei ] && GO111MODULE=on go get -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@v2.5.2
         echo "/home/runner/go/bin/" >> $GITHUB_PATH
+        echo "::endgroup::"
       shell: bash
 
     - run: |


### PR DESCRIPTION
This addresses https://github.com/projectdiscovery/nuclei-action/issues/25 by using the `::group::`/`::endgroup::` lines to collapse the `go get` output into an expandable group, per https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#grouping-log-lines.

The Nuclei run results are now visible in the GitHub Actions UI without scrolling, and `go get` output can be viewed by expanding that "Install Nuclei with go get" group if need be.

<img width="918" alt="CleanShot 2021-10-08 at 08 27 18@2x" src="https://user-images.githubusercontent.com/421063/136584638-6d7e7671-be67-44d7-b8bf-02a562c86eee.png">

