### PR TITLE
Use nuclei 2.5.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
   steps:
     - run: |
         echo "::group::Install Nuclei with go get"
-        [ ! -x /home/runner/go/bin/nuclei ] && GO111MODULE=on go get -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@v2.5.2
+        [ ! -x /home/runner/go/bin/nuclei ] && GO111MODULE=on go get -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@v2.5.4
         echo "/home/runner/go/bin/" >> $GITHUB_PATH
         echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
Currently it fails with:
```
[FTL] Could not run nuclei: no valid templates were found
```
I'm not sure if this is related to breaking change in 2.5.3 or something else.