### PR TITLE
version update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
   steps:
     - run: |
         echo "::group::Install Nuclei with go get"
-        [ ! -x /home/runner/go/bin/nuclei ] && go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@v2.5.4
+        [ ! -x /home/runner/go/bin/nuclei ] && go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@v2.5.8
         echo "/home/runner/go/bin/" >> $GITHUB_PATH
         echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
Due to the older version it was observed that the Github actions workflow would fail with the following error,
```
 go: downloading github.com/projectdiscovery/nuclei v2.5.4+incompatible
  go install: github.com/projectdiscovery/nuclei/v2/cmd/nuclei@v2.5.4: module github.com/projectdiscovery/nuclei@v2.5.4 found (v2.5.4+incompatible), but does not contain package github.com/projectdiscovery/nuclei/v2/cmd/nuclei
  Error: Process completed with exit code 1.
```
