### PR TITLE
Switch -json to -jsonl

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9932,7 +9932,7 @@ async function run() {
     if (config) params.push(`-config=${config}`);
     if (userAgent) params.push(`-H=${userAgent}`);
     params.push(`-o=${ output ? output : 'nuclei.log' }`);
-    if (src_json) params.push('-json');
+    if (src_json) params.push('-jsonl');
     if (includeRR) params.push('-irr');
 
     if (flags) params.push(...parseFlagsToArray(flags));


### PR DESCRIPTION
Nuclei version v2.9.1 includes a breaking change because the option -json has been changed to -jsonl

The action currently fails if we use the parameter JSON as it uses the old option -json.

